### PR TITLE
Change `uuid` dependency to community maintained fork

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -1,7 +1,7 @@
 package kasa
 
 import (
-	uuid "github.com/satori/go.uuid"
+	uuid "github.com/gofrs/uuid"
 )
 
 type auth struct {


### PR DESCRIPTION
> github.com/gofrs/uuid is no longer being actively maintained
> See https://github.com/satori/go.uuid/issues/84 for more detail

---
The dependency [satori/go.uuid](https://github.com/satori/go.uuid) causes the following:
```
$ go get github.com/ivanbeldad/kasa-go
go: github.com/ivanbeldad/kasa-go upgrade => v0.0.0-20191206080011-613ab073653e
go: finding module for package github.com/satori/go.uuid
go: found github.com/satori/go.uuid in github.com/satori/go.uuid v1.2.0
# github.com/ivanbeldad/kasa-go
/Users/guywithacube/go/pkg/mod/github.com/ivanbeldad/kasa-go@v0.0.0-20191206080011-613ab073653e/auth.go:32:12: assignment mismatch: 2 variables but uuid.NewV4 returns 1 values
```

Following the advice from https://github.com/satori/go.uuid/issues/84, I think it would be wise to move towards an actively maintained fork.